### PR TITLE
Replace ifs.cloud with nytimes.com in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,149 +1,93 @@
-# Henry the Navigator - Network Traffic Analysis Tool
+# rec
 
-A professional Python-based network traffic capture and analysis system using mitmproxy. Henry the Navigator charts uncharted digital waters by automatically generating comprehensive API documentation, interactive timelines, and real-time traffic analysis from browser sessions.
+Record and inspect HTTP traffic for a domain.
 
-## Quick Start
-
-```bash
-# Start traffic capture with automatic analysis
-make run
-
-# Browse normally - all traffic is captured automatically
-
-# Stop capture and generate comprehensive reports
-make stop
-
-# View results
-make viewer       # Interactive API documentation (Swagger UI)
-make open-timeline # Chronological timeline of API calls
-make view         # Browse organized results by domain
-```
-
-**Complete documentation:** See [addons.md](addons.md) for enhanced features reference.
-
-## Installation
+## Install
 
 ```bash
-# Install mitmproxy
-brew install mitmproxy
-
-# Install certificate (one-time setup)
-make run
-# Visit http://mitm.it in your browser to download and install certificate
-# Then stop: make stop
+brew install sstrelsov/tap/rec
 ```
 
-## Commands
-
-| Command | Description |
-|---------|-------------|
-| `make run` | Start enhanced capture with API documentation and timeline generation |
-| `make stop` | Stop capture and auto-generate all reports |
-| `make viewer` | Open interactive API documentation (Swagger UI) |
-| `make open-timeline` | Open chronological timeline of API calls |
-| `make view` | Browse organized results by domain |
-| `make config` | Show current configuration |
-| `make status` | Check current capture status |
-| `make basic` | Run in basic mode (no enhanced features) |
-| `make clean` | Remove all output files |
-
-## Core Features
-
-### Traffic Organization
-- **Domain-based structure**: APIs automatically organized by base domain
-- **Executable commands**: Each request saved as HTTPie command for replay
-- **Zero configuration**: Works immediately with sensible defaults
-- **Clean workflow**: Simple commands handle complete capture-to-analysis pipeline
-
-### Enhanced Analysis
-- **OpenAPI documentation**: Auto-generates professional Swagger specifications from live traffic
-- **Interactive timeline**: Chronological visualization of all API interactions
-- **Real-time monitoring**: Live analysis with performance insights during capture
-- **Smart filtering**: Automatically excludes advertising and analytics noise
-- **Professional output**: Documentation quality that rivals official API specifications
-
-## Output Structure
-
-Henry organizes captured traffic into a clear hierarchy:
-
-- **Domain-separated API calls** in individual directories
-- **Executable HTTPie commands** for request reproduction
-- **Complete JSON responses** for analysis
-- **Smart filtering** by domain, HTTP method, and response status
-- **Traffic summaries** with timing and payload size data
-
-## Example Session
+Or clone and run directly:
 
 ```bash
-# Analyze Airbnb's API structure
-make run
-# Navigate Airbnb.com normally...
-make stop
-
-# Generated structure:
-# output/
-# └── airbnb.com/
-#     ├── get_stayspdpsections_token_2025-08-02_21-51-05_008/
-#     │   ├── request.json    # HTTPie command
-#     │   ├── response.json   # API response
-#     │   ├── auth.txt        # Authentication details
-#     │   └── metadata.json   # Request metadata
-#     └── post_authenticate_2025-08-02_21-50-12_003/
-#         ├── request.json
-#         └── response.json
-
-make view
-# Organized APIs: output/
-# Found 47 API calls across 3 domains:
-#   airbnb.com: 23 calls
-#   api.openai.com: 12 calls
-#   github.com: 12 calls
+git clone https://github.com/sstrelsov/rec.git
+cd rec
+pip install -r requirements.txt
 ```
 
-## Advanced Usage
+## Usage
 
 ```bash
-# Direct Python interface
-python mitmtool.py run --output custom.mitm
-python mitmtool.py view --input custom.mitm --domain airbnb
-python mitmtool.py organize --input custom.mitm --output my_analysis
-
-# Domain-specific filtering
-python mitmtool.py view --domain api.openai.com
+rec on nytimes.com    # Start recording, filtered to nytimes.com
+rec on              # Start recording ALL traffic
+rec off             # Stop recording
+rec view            # Show capture directories
+rec status          # Check if recording
 ```
+
+## How it works
+
+`rec` uses [mitmproxy](https://mitmproxy.org/) to capture HTTP/HTTPS traffic through a local proxy. When you run `rec on`, it:
+
+1. Enables the macOS system proxy
+2. Starts `mitmdump` with traffic recording addons
+3. Saves captures to `~/.rec/<domain>/`
+
+When you run `rec off`, it stops the proxy and restores normal networking.
+
+## Output structure
+
+```
+~/.rec/
+  nytimes.com/                            # Domain-scoped captures
+    capture_20260226_143015.mitm          # Raw mitmproxy dump
+    nytimes.com/                          # Recorded calls by root domain
+      get_landing-page_..._001/
+        request.json
+        response.json
+        auth.txt
+      metadata.json
+  all/                                    # Unfiltered captures (rec on)
+    capture_20260226_150000.mitm
+    ...
+```
+
+Each recorded call includes:
+- **request.json** - Method, URL, headers, body (auth tokens replaced with `{{auth_token}}`)
+- **response.json** - Response body in native format (JSON, XML, HTML, or text)
+- **auth.txt** - Extracted authentication token
+- **metadata.json** - Domain-level stats and endpoint summary
 
 ## Configuration
 
-Customize behavior by editing the configuration file:
+Optional config at `~/.rec/config.toml`:
 
-```bash
-# Primary settings in config.toml
-OUTPUT_DIR=output
-VIEWER_PORT=8000
+```toml
+[filtering]
+http_methods = ["GET", "POST", "PUT", "PATCH", "DELETE"]
+filter_static_assets = true
+filter_browser_housekeeping = true
+
+blocked_patterns = [
+    "google-analytics.com",
+    "facebook.net",
+]
 ```
 
-View current configuration: `make config`
+See the shipped `config.toml` for all options.
 
-## Architecture
+## Certificate setup
 
-```
-mitmtool.py        # Main CLI interface
-├── config.py        # Configuration management (TOML-based)
-├── proxy_manager.py # macOS proxy system control
-├── capture.py       # Traffic capture and organization
-├── parser.py        # Flow parsing and analysis
-├── generate_reports.py # Enhanced reporting system
-└── makefile         # Workflow automation
-```
+On first use, install the mitmproxy CA certificate:
 
-## Security Considerations
+1. Run `rec on` to start the proxy
+2. Visit [http://mitm.it](http://mitm.it) in your browser
+3. Download and install the certificate for your OS
+4. Trust the certificate in Keychain Access (macOS)
 
-- **Comprehensive capture**: Records ALL browser traffic including sensitive data
-- **Session management**: Always execute `make stop` when analysis complete
-- **Certificate management**: Monitor for certificate warnings in browser
-- **Isolation recommended**: Consider using dedicated browser profiles for analysis
+## Requirements
 
----
-
-**Certificate installation:** http://mitm.it  
-**Help and documentation:** `make help`
+- macOS (uses `networksetup` for proxy control)
+- Python 3.11+
+- mitmproxy (`brew install mitmproxy`)

--- a/domain_utils.py
+++ b/domain_utils.py
@@ -2,133 +2,172 @@
 """
 domain_utils.py - Domain parsing and grouping utilities
 
-Provides functions to extract root domains from URLs and group subdomains
-under their parent domains for better organization in timeline and API docs.
+Provides functions to extract root domains from URLs, match against target
+domains, and group subdomains under their parent domains.
 """
 
 import re
 from urllib.parse import urlparse
-from typing import Optional
+from typing import List, Optional
 
 
 def extract_root_domain(hostname: str) -> str:
     """
     Extract the root domain from a hostname.
-    
+
     Examples:
     - api.example.com -> example.com
     - graphql.nytimes.com -> nytimes.com
     - subdomain.service.example.co.uk -> example.co.uk
     - localhost -> localhost
     - 192.168.1.1 -> 192.168.1.1
-    
-    Args:
-        hostname: The hostname to extract root domain from
-        
-    Returns:
-        The root domain string
+    - api.example.com:8080 -> example.com
     """
     if not hostname:
         return hostname
-    
+
     hostname = hostname.lower().strip()
-    
+
+    # Strip port number
+    if ':' in hostname and not _is_ip_v6(hostname):
+        hostname = hostname.rsplit(':', 1)[0]
+
     # Handle IP addresses (IPv4 and IPv6)
     if _is_ip_address(hostname):
         return hostname
-    
+
     # Handle localhost and local development domains
     if hostname in ['localhost', '127.0.0.1', '::1'] or hostname.endswith('.local'):
         return hostname
-    
+
     # Split hostname into parts
     parts = hostname.split('.')
-    
+
     # If less than 2 parts, return as-is (e.g., "localhost")
     if len(parts) < 2:
         return hostname
-    
+
     # Handle common two-level TLDs (e.g., .co.uk, .com.au, .github.io)
     two_level_tlds = {
         'co.uk', 'com.au', 'co.jp', 'co.kr', 'co.nz', 'co.za',
         'github.io', 'herokuapp.com', 'netlify.app', 'vercel.app',
         'github.dev', 'gitpod.io', 'repl.co', 'glitch.me'
     }
-    
+
     # Check if the last two parts form a two-level TLD
     if len(parts) >= 3:
         potential_tld = f"{parts[-2]}.{parts[-1]}"
         if potential_tld in two_level_tlds:
-            # Return domain.tld.suffix (e.g., example.co.uk)
-            if len(parts) >= 3:
-                return f"{parts[-3]}.{parts[-2]}.{parts[-1]}"
-            else:
-                return hostname
-    
+            return f"{parts[-3]}.{parts[-2]}.{parts[-1]}"
+
     # Standard case: return the last two parts (domain.tld)
-    if len(parts) >= 2:
-        return f"{parts[-2]}.{parts[-1]}"
-    
-    return hostname
+    return f"{parts[-2]}.{parts[-1]}"
+
+
+def _is_ip_v6(hostname: str) -> bool:
+    """Check if hostname looks like IPv6 (contains multiple colons)."""
+    return hostname.count(':') >= 2 or '::' in hostname
 
 
 def _is_ip_address(hostname: str) -> bool:
     """Check if hostname is an IP address (IPv4 or IPv6)."""
-    # Simple IPv4 check
     ipv4_pattern = re.compile(r'^(\d{1,3}\.){3}\d{1,3}$')
     if ipv4_pattern.match(hostname):
         return True
-    
-    # Simple IPv6 check (basic patterns)
-    if ':' in hostname and (hostname.count(':') >= 2 or '::' in hostname):
+
+    if _is_ip_v6(hostname):
         return True
-    
+
+    return False
+
+
+def parse_domain_input(raw: str) -> str:
+    """
+    Parse user-provided domain input into a clean root domain.
+
+    Handles:
+    - Full URLs: https://api.nytimes.com/svc/search/ -> nytimes.com
+    - Bare domains: nytimes.com -> nytimes.com
+    - Domains with ports: nytimes.com:8080 -> nytimes.com
+    - Subdomains: api.nytimes.com -> nytimes.com
+    """
+    raw = raw.strip()
+
+    # If it looks like a URL (has scheme), parse it
+    if '://' in raw:
+        parsed = urlparse(raw)
+        hostname = parsed.hostname or parsed.netloc
+        if hostname:
+            return extract_root_domain(hostname)
+
+    # Otherwise treat as hostname (possibly with port)
+    return extract_root_domain(raw)
+
+
+def matches_target_domains(hostname: str, target_domains: List[str]) -> bool:
+    """
+    Check if a hostname matches any of the target domains.
+
+    A hostname matches if its root domain equals a target domain's root domain.
+    Empty target_domains list means match everything.
+
+    Examples:
+        matches_target_domains("api.nytimes.com", ["nytimes.com"]) -> True
+        matches_target_domains("google.com", ["nytimes.com"]) -> False
+        matches_target_domains("anything.com", []) -> True
+    """
+    if not target_domains:
+        return True
+
+    host_root = extract_root_domain(hostname)
+    for target in target_domains:
+        if host_root == extract_root_domain(target):
+            return True
     return False
 
 
 def get_domain_hierarchy(hostname: str) -> dict:
     """
     Get domain hierarchy information for grouping.
-    
+
     Returns:
         Dict with 'root_domain', 'full_domain', and 'subdomain' info
     """
     root_domain = extract_root_domain(hostname)
-    
+
     result = {
         'root_domain': root_domain,
         'full_domain': hostname,
         'is_subdomain': hostname != root_domain,
         'subdomain': None
     }
-    
+
     # Extract subdomain if it exists
     if result['is_subdomain'] and not _is_ip_address(hostname):
-        # Remove the root domain from the end to get subdomain
         if hostname.endswith(f".{root_domain}"):
             subdomain = hostname[:-len(f".{root_domain}")]
             result['subdomain'] = subdomain
-    
+
     return result
 
 
 def group_domains_by_root(domains: list) -> dict:
     """
     Group a list of domains by their root domain.
-    
+
     Args:
         domains: List of domain strings
-        
+
     Returns:
         Dict mapping root domains to lists of full domains
     """
     grouped = {}
-    
+
     for domain in domains:
         root = extract_root_domain(domain)
         if root not in grouped:
             grouped[root] = []
         if domain not in grouped[root]:
             grouped[root].append(domain)
-    
+
     return grouped

--- a/rec
+++ b/rec
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+rec - Record and inspect HTTP traffic for a domain.
+
+Usage:
+    rec on [domain]   Start recording (optionally filtered to domain)
+    rec off           Stop recording
+    rec view          Show capture directory
+    rec status        Check if recording
+"""
+
+import argparse
+import os
+import signal
+import sys
+from pathlib import Path
+
+from proxy_manager import ProxyManager
+from capture import TrafficCapture
+from domain_utils import parse_domain_input
+
+REC_DIR = Path(os.environ.get("REC_DIR", "~/.rec")).expanduser()
+PID_FILE = REC_DIR / ".pid"
+ACTIVE_FILE = REC_DIR / ".active"
+
+
+def cmd_on(args):
+    """Start recording traffic."""
+    # Check if already recording
+    if PID_FILE.exists():
+        try:
+            pid = int(PID_FILE.read_text().strip())
+            os.kill(pid, 0)  # Check if process is alive
+            domain = ACTIVE_FILE.read_text().strip() if ACTIVE_FILE.exists() else "all"
+            print(f"Already recording ({domain}). Run 'rec off' first.")
+            return 1
+        except (ProcessLookupError, ValueError):
+            # Stale PID file, clean up
+            _cleanup_state()
+
+    # Parse domain
+    domain = None
+    if args.domain:
+        domain = parse_domain_input(args.domain)
+
+    label = domain or "all"
+    output_dir = str(REC_DIR / label)
+
+    # Set env vars for addons
+    if domain:
+        os.environ["HENRY_DOMAINS"] = domain
+    os.environ["HENRY_OUTPUT_DIR"] = output_dir
+
+    # Ensure base directory exists
+    REC_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Enable proxy
+    proxy = ProxyManager()
+    if not proxy.enable_proxy():
+        print("Failed to enable proxy.")
+        return 1
+
+    print(f"Recording {label} -> {output_dir}")
+
+    # Launch capture (blocks until Ctrl+C)
+    capture = TrafficCapture()
+
+    # Write state files before blocking
+    _write_state(os.getpid(), label)
+
+    # Register cleanup for when capture ends
+    original_sigint = signal.getsignal(signal.SIGINT)
+
+    def cleanup_handler(signum, frame):
+        print("\nStopping...")
+        capture.stop_capture()
+        proxy.disable_proxy()
+        _cleanup_state()
+        print(f"Stopped. Captures in {output_dir}")
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, cleanup_handler)
+    signal.signal(signal.SIGTERM, cleanup_handler)
+
+    success = capture.start_capture(output_dir)
+
+    # If start_capture returns (process ended), clean up
+    proxy.disable_proxy()
+    _cleanup_state()
+
+    if not success:
+        print(f"Capture failed.")
+        return 1
+
+    print(f"Stopped. Captures in {output_dir}")
+    return 0
+
+
+def cmd_off(args):
+    """Stop recording traffic."""
+    if not PID_FILE.exists():
+        print("Not recording.")
+        return 1
+
+    try:
+        pid = int(PID_FILE.read_text().strip())
+    except ValueError:
+        _cleanup_state()
+        print("Not recording (cleaned up stale state).")
+        return 1
+
+    domain = ACTIVE_FILE.read_text().strip() if ACTIVE_FILE.exists() else "all"
+    output_dir = str(REC_DIR / domain)
+
+    # Kill the capture process
+    try:
+        os.kill(pid, signal.SIGTERM)
+        print(f"Stopped recording.")
+    except ProcessLookupError:
+        print("Process already stopped.")
+
+    # Disable proxy
+    proxy = ProxyManager()
+    proxy.disable_proxy()
+
+    # Clean up state
+    _cleanup_state()
+
+    print(f"Captures in {output_dir}")
+    return 0
+
+
+def cmd_view(args):
+    """Show capture directories."""
+    if ACTIVE_FILE.exists():
+        try:
+            pid = int(PID_FILE.read_text().strip()) if PID_FILE.exists() else None
+            if pid:
+                os.kill(pid, 0)
+                domain = ACTIVE_FILE.read_text().strip()
+                print(f"Currently recording: {REC_DIR / domain}")
+                return 0
+        except (ProcessLookupError, ValueError):
+            pass
+
+    # List all capture directories sorted by modification time (latest first)
+    if not REC_DIR.exists():
+        print(f"No captures yet. Run 'rec on' to start.")
+        return 0
+
+    dirs = [
+        d for d in REC_DIR.iterdir()
+        if d.is_dir() and not d.name.startswith('.')
+    ]
+
+    if not dirs:
+        print(f"No captures yet. Run 'rec on' to start.")
+        return 0
+
+    dirs.sort(key=lambda d: d.stat().st_mtime, reverse=True)
+
+    print("Captures:")
+    for d in dirs:
+        # Count subdirectories (call recordings)
+        call_dirs = [c for c in d.iterdir() if c.is_dir()]
+        mitm_files = list(d.glob("*.mitm"))
+        parts = []
+        if call_dirs:
+            parts.append(f"{len(call_dirs)} calls")
+        if mitm_files:
+            parts.append(f"{len(mitm_files)} captures")
+        detail = f" ({', '.join(parts)})" if parts else ""
+        print(f"  {d}{detail}")
+
+    return 0
+
+
+def cmd_status(args):
+    """Check recording status."""
+    if not PID_FILE.exists():
+        print("Not recording.")
+        return 0
+
+    try:
+        pid = int(PID_FILE.read_text().strip())
+        os.kill(pid, 0)
+        domain = ACTIVE_FILE.read_text().strip() if ACTIVE_FILE.exists() else "all"
+        output_dir = REC_DIR / domain
+        print(f"Recording {domain} (pid {pid})")
+        print(f"Output: {output_dir}")
+        return 0
+    except (ProcessLookupError, ValueError):
+        _cleanup_state()
+        print("Not recording (cleaned up stale state).")
+        return 0
+
+
+def _write_state(pid: int, domain: str):
+    """Write PID and active domain state files."""
+    REC_DIR.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(str(pid))
+    ACTIVE_FILE.write_text(domain)
+
+
+def _cleanup_state():
+    """Remove PID and active domain state files."""
+    PID_FILE.unlink(missing_ok=True)
+    ACTIVE_FILE.unlink(missing_ok=True)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="rec",
+        description="Record and inspect HTTP traffic for a domain.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  rec on nytimes.com    Record traffic for nytimes.com
+  rec on              Record all traffic
+  rec off             Stop recording
+  rec view            Show capture directories
+  rec status          Check if recording
+""",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    on_parser = subparsers.add_parser("on", help="Start recording")
+    on_parser.add_argument("domain", nargs="?", default=None,
+                           help="Domain to filter (e.g. nytimes.com)")
+
+    subparsers.add_parser("off", help="Stop recording")
+    subparsers.add_parser("view", help="Show capture directories")
+    subparsers.add_parser("status", help="Check if recording")
+
+    return parser
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+
+    if not args.command:
+        print("rec - Record and inspect HTTP traffic\n")
+        print("  rec on [domain]   Start recording")
+        print("  rec off           Stop recording")
+        print("  rec view          Show captures")
+        print("  rec status        Check status")
+        print("\nRun 'rec --help' for details.")
+        return
+
+    commands = {
+        "on": cmd_on,
+        "off": cmd_off,
+        "view": cmd_view,
+        "status": cmd_status,
+    }
+
+    try:
+        handler = commands[args.command]
+        sys.exit(handler(args))
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+        sys.exit(0)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Replace all `ifs.cloud` references with `nytimes.com` in CLI help, README, and docstrings
- Use a well-known public domain that makes better example material
- Updated `rec`, `README.md`, and `domain_utils.py`

## Test plan
- [x] `python3 -c "import py_compile; py_compile.compile('rec'); py_compile.compile('domain_utils.py')"` passes
- [x] `rec --help` shows `nytimes.com` in examples
- [x] `grep -r 'ifs\.cloud'` returns no matches